### PR TITLE
Fix hero image appearance on large displays

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -10164,7 +10164,8 @@ body.search-mode .search-panel {
 /* line 25, ../sass/components/_slider.scss */
 
 .carousel-inner > .item > img {
-  max-width: none;
+  min-width: 1920px;
+  width: 100%;
 }
 
 /* line 29, ../sass/components/_slider.scss */


### PR DESCRIPTION
The hero image does not span the entire width of the screen on large displays (I noticed because I'm running at 2560x1440 - see screenshot below).

![image](https://cloud.githubusercontent.com/assets/183833/10569432/f43ba9e4-75f3-11e5-9d54-bb6a4aff2a9c.png)

This change ensures that the image won't shrink below 1920px wide on smaller displays, but will allow it to stretch the width of the screen on larger displays (see screenshot below).

![image](https://cloud.githubusercontent.com/assets/183833/10569475/889325b8-75f4-11e5-9f6d-e0b6483ce9cd.png)
